### PR TITLE
This pull request adds support for Azure to the CLI, which currently …

### DIFF
--- a/src/utils/read-directory.ts
+++ b/src/utils/read-directory.ts
@@ -30,6 +30,7 @@ async function listFiles(directoryOrFilePath: string): Promise<string[]> {
         // escape regex special characters that might be in the extension
         return ext.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
       })
+      .concat(['.az'])  // Assuming '.az' as Azure-specific file extension
       .join('|');
 
     const EXT_REGEX = new RegExp(`.*(${EXT_REGEX_PARTIAL})$`, 'g');

--- a/src/utils/scanner-strategies/index.ts
+++ b/src/utils/scanner-strategies/index.ts
@@ -1,5 +1,6 @@
 import GCPScanner from './gcp';
 import AWSScanner from './aws';
+import AzureScanner from './azure';
 import { CloudProviders } from '@slauth.io/langchain-wrapper';
 import ScannerStrategy from '../../types/scanner-strategy';
 
@@ -10,6 +11,7 @@ type ScannerStrategiesType = {
 const ScannerStrategies: ScannerStrategiesType = {
   gcp: new GCPScanner(),
   aws: new AWSScanner(),
+  azure: new AzureScanner(),
 };
 
 export default ScannerStrategies;


### PR DESCRIPTION
…only supports GCP and AWS. The main changes are:

1. Added a new `AzureScanner` class to the `scanner-strategies` module, which implements the `ScannerStrategy` interface. This allows the CLI to interact with Azure resources in the same way it does with GCP and AWS.

2. Updated the `listFiles` function in the `read-directory.ts` module to include the `.az` file extension, which is assumed to be the extension for Azure-specific files. This ensures that the CLI can properly read and process Azure-related files.

These changes will allow the CLI to expand its platform support and provide users with the ability to work with Azure resources alongside GCP and AWS.