### PR TITLE
Model name parameter modified to accept string

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -6,18 +6,18 @@ import showAsyncSpinner from '../utils/show-async-spinner';
 import { yellow, red, green } from '../utils/colors';
 import writeToFile from '../utils/write-to-file';
 import isGitRepository from '../utils/is-git-repository';
-import { CloudProviders, OpenAIModels } from '@slauth.io/langchain-wrapper';
+import { CloudProviders } from '@slauth.io/langchain-wrapper';
 import ScannerStrategies from '../utils/scanner-strategies';
 import Scanner from '../utils/scanner';
 
 const scanCommand = new Command();
 scanCommand
   .name('scan')
-  .description('scan a repository and generate least priviledge policies')
+  .description('Scan a repository and generate least privilege policies')
   .addOption(
     new Option(
       '-p, --cloud-provider <cloudProvider>',
-      'select the cloud provider you would like to generate policies for'
+      'Select the cloud provider you would like to generate policies for'
     )
       .choices(Object.values(CloudProviders))
       .makeOptionMandatory(true)
@@ -25,14 +25,14 @@ scanCommand
   .addOption(
     new Option(
       '-m, --openai-model <openaiModel>',
-      'select the openai model to use'
-    ).choices(Object.values(OpenAIModels))
+      'Specify the OpenAI model to use (e.g., "gpt-3.5-turbo", "gpt-4")'
+    )
   )
   .option(
     '-o, --output-file <outputFile>',
-    'write generated policies to a file instead of stdout'
+    'Write generated policies to a file instead of stdout'
   )
-  .argument('<path>', 'repository path')
+  .argument('<path>', 'Repository path')
   .action(async (pathArg, { cloudProvider, openaiModel, outputFile }) => {
     try {
       const fullPath = path.resolve(process.cwd(), pathArg);
@@ -72,7 +72,7 @@ function getResultType(cloudProvider: keyof typeof CloudProviders) {
 async function scan(
   fullPath: string,
   cloudProvider: keyof typeof CloudProviders,
-  modelName?: keyof typeof OpenAIModels
+  modelName?: string
 ) {
   if (!isGitRepository(fullPath)) {
     throw new Error('Directory needs to be a Git repository');
@@ -89,7 +89,7 @@ async function scan(
   );
 
   const scanner = new Scanner(ScannerStrategies[cloudProvider]);
-  const codeSnippets = (await readDirectoryPromise).map(doc => doc.pageContent);
+  const codeSnippets = (await readDirectoryPromise).map((doc) => doc.pageContent);
   return await scanner.scan(codeSnippets, modelName);
 }
 

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -89,7 +89,7 @@ async function scan(
   );
 
   const scanner = new Scanner(ScannerStrategies[cloudProvider]);
-  const codeSnippets = (await readDirectoryPromise).map((doc) => doc.pageContent);
+  const codeSnippets = (await readDirectoryPromise).map(doc => doc.pageContent);
   return await scanner.scan(codeSnippets, modelName);
 }
 

--- a/src/types/scanner-strategy.ts
+++ b/src/types/scanner-strategy.ts
@@ -1,4 +1,3 @@
-
 export default interface ScannerStrategy {
   scan(
     codeSnippets: string[],

--- a/src/types/scanner-strategy.ts
+++ b/src/types/scanner-strategy.ts
@@ -1,8 +1,7 @@
-import { OpenAIModels } from '@slauth.io/langchain-wrapper';
 
 export default interface ScannerStrategy {
   scan(
     codeSnippets: string[],
-    modelName?: keyof typeof OpenAIModels
+    modelName?: string
   ): Promise<unknown[] | undefined>;
 }

--- a/src/utils/scanner-strategies/aws.ts
+++ b/src/utils/scanner-strategies/aws.ts
@@ -1,13 +1,13 @@
-import { OpenAIModels, Services } from '@slauth.io/langchain-wrapper';
+import { Services } from '@slauth.io/langchain-wrapper';
 import ScannerStrategy from '../../types/scanner-strategy';
 import showAsyncSpinner from '../show-async-spinner';
 import spinners from 'cli-spinners';
 import { yellow } from '../colors';
 
 export default class AWSScanner implements ScannerStrategy {
-  async scan(codeSnippets: string[], modelName: keyof typeof OpenAIModels) {
+  async scan(codeSnippets: string[], modelName?: string) {
     const statementsPromises = Promise.all(
-      codeSnippets.map(async snippet => {
+      codeSnippets.map(async (snippet) => {
         return await Services.aws.getStatementsFromCode(snippet, modelName);
       })
     );

--- a/src/utils/scanner-strategies/aws.ts
+++ b/src/utils/scanner-strategies/aws.ts
@@ -7,7 +7,7 @@ import { yellow } from '../colors';
 export default class AWSScanner implements ScannerStrategy {
   async scan(codeSnippets: string[], modelName?: string) {
     const statementsPromises = Promise.all(
-      codeSnippets.map(async (snippet) => {
+      codeSnippets.map(async snippet => {
         return await Services.aws.getStatementsFromCode(snippet, modelName);
       })
     );

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -1,4 +1,3 @@
-import { OpenAIModels } from '@slauth.io/langchain-wrapper';
 import ScannerStrategy from '../types/scanner-strategy';
 
 export default class Scanner {
@@ -10,7 +9,7 @@ export default class Scanner {
 
   public async scan(
     codeSnippets: string[],
-    modelName?: keyof typeof OpenAIModels
+    modelName?: string
   ) {
     return await this.strategy.scan(codeSnippets, modelName);
   }

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -7,10 +7,7 @@ export default class Scanner {
     this.strategy = strategy;
   }
 
-  public async scan(
-    codeSnippets: string[],
-    modelName?: string
-  ) {
+  public async scan(codeSnippets: string[], modelName?: string) {
     return await this.strategy.scan(codeSnippets, modelName);
   }
 }


### PR DESCRIPTION
Made changes to the Command file to accept all model paramters as a sring.
Made changes to achieve the following:

Accepts any string as a model parameter and calls the LLM  with the given model parameter string.
Throws an error when the string is sent as model parmeter and if such model doesnt exist.